### PR TITLE
Reverting API endpoint examples

### DIFF
--- a/code-samples/api_paging_csvoutput.sh
+++ b/code-samples/api_paging_csvoutput.sh
@@ -3,7 +3,7 @@
 
 # Base URL for this endpoint with $inlinecount set to return total record count. Add 
 #   filters, column selection, and sort order to the end of the baseURL
-baseUrl='https://www.fema.gov/api/open/v2/FemaWebDisasterDeclarations?$inlinecount=allpages'
+baseUrl='https://www.fema.gov/api/open/v1/FemaWebDisasterDeclarations?$inlinecount=allpages'
 
 # Return 1 record with your criteria to get total record count. Specifying only 1
 #   column here to reduce amount of data returned. The backslashes are needed before

--- a/code-samples/api_paging_jsonoutput.py
+++ b/code-samples/api_paging_jsonoutput.py
@@ -8,7 +8,7 @@ import math
 from datetime import datetime
 
 # Base URL for this endpoint. Add filters, column selection, and sort order to this.
-baseUrl = "https://www.fema.gov/api/open/v2/FemaWebDisasterDeclarations?"
+baseUrl = "https://www.fema.gov/api/open/v1/FemaWebDisasterDeclarations?"
 
 top = 1000      # number of records to get per call
 skip = 0        # number of records to skip

--- a/code-samples/api_paging_jsonoutput.sh
+++ b/code-samples/api_paging_jsonoutput.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Paging example using bash. Output in JSON.
 
-baseUrl='https://www.fema.gov/api/open/v2/FemaWebDisasterDeclarations?$inlinecount=allpages'
+baseUrl='https://www.fema.gov/api/open/v1/FemaWebDisasterDeclarations?$inlinecount=allpages'
 
 # Return 1 record with your criteria to get total record count. Specifying only 1
 #   column here to reduce amount of data returned. The backslashes are needed before

--- a/code-samples/api_paging_rdsoutput.r
+++ b/code-samples/api_paging_rdsoutput.r
@@ -8,7 +8,7 @@ require("httr")         # wrapper for curl package - may require installation
 
 datalist = list()       # a list that will hold the results of each call
 
-baseUrl <- "https://www.fema.gov/api/open/v2/FemaWebDisasterDeclarations?"
+baseUrl <- "https://www.fema.gov/api/open/v1/FemaWebDisasterDeclarations?"
 
 # Determine record count. Specifying only 1 column here to reduce amount of data returned. 
 #   Remember to add criteria/filter here (if you have any) to get an accurate count.


### PR DESCRIPTION
These API endpoints were changed in commit d3e860d, but according to OpenFEMA's own [documentation](https://www.fema.gov/about/openfema/data-sets), combined with real world use, have not been updated to v2. If one attempted to run one of these files before reverting to v1, they would have received an HTTP 404 error. 